### PR TITLE
Add password encoder configuration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,6 +61,10 @@
                         <scope>test</scope>
                 </dependency>
                 <dependency>
+                        <groupId>org.springframework.security</groupId>
+                        <artifactId>spring-security-crypto</artifactId>
+                </dependency>
+                <dependency>
                         <groupId>org.mapstruct</groupId>
                         <artifactId>mapstruct</artifactId>
                         <version>1.5.5.Final</version>

--- a/src/main/java/Neuroflow/backend/BackendApplication.java
+++ b/src/main/java/Neuroflow/backend/BackendApplication.java
@@ -1,6 +1,7 @@
 package Neuroflow.backend;
 
 import Neuroflow.backend.config.DataBaseConfig;
+import Neuroflow.backend.config.SecurityConfig;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -9,7 +10,7 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
 @EnableJpaRepositories
-@Import(DataBaseConfig.class)
+@Import({DataBaseConfig.class, SecurityConfig.class})
 public class BackendApplication {
 
     public static void main(String[] args) {

--- a/src/main/java/Neuroflow/backend/config/SecurityConfig.java
+++ b/src/main/java/Neuroflow/backend/config/SecurityConfig.java
@@ -1,0 +1,15 @@
+package Neuroflow.backend.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}


### PR DESCRIPTION
## Summary
- add Spring Security crypto dependency and password encoder bean
- include SecurityConfig in application setup

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a04e73348324838428217490654f