### PR TITLE
Replace Lombok usage in user DTOs

### DIFF
--- a/src/main/java/Neuroflow/backend/user/dto/UserCreateRequest.java
+++ b/src/main/java/Neuroflow/backend/user/dto/UserCreateRequest.java
@@ -1,17 +1,14 @@
 package Neuroflow.backend.user.dto;
 
 import jakarta.validation.constraints.*;
-
 import Neuroflow.backend.user.entity.User.Role;
-import lombok.Data;
 
 /**
  * Request body for creating a {@code User}.
  *
- * <p>The {@link Data} annotation supplies the required getters and setters for
- * the mapper and service layers.</p>
+ * <p>Lombok has been removed from this project; therefore, explicit getters
+ * and setters are implemented to expose the request properties.</p>
  */
-@Data
 public class UserCreateRequest {
     @NotBlank @Size(max=64)  private String username;
     @NotBlank @Email         private String email;
@@ -20,4 +17,26 @@ public class UserCreateRequest {
     @Size(max=80)            private String lastName;
     private Role role = Role.USER;
     private boolean enabled = true;
+
+    // getters and setters
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+
+    public String getPassword() { return password; }
+    public void setPassword(String password) { this.password = password; }
+
+    public String getFirstName() { return firstName; }
+    public void setFirstName(String firstName) { this.firstName = firstName; }
+
+    public String getLastName() { return lastName; }
+    public void setLastName(String lastName) { this.lastName = lastName; }
+
+    public Role getRole() { return role; }
+    public void setRole(Role role) { this.role = role; }
+
+    public boolean isEnabled() { return enabled; }
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
 }

--- a/src/main/java/Neuroflow/backend/user/dto/UserDto.java
+++ b/src/main/java/Neuroflow/backend/user/dto/UserDto.java
@@ -1,15 +1,15 @@
 package Neuroflow.backend.user.dto;
 
 import Neuroflow.backend.user.entity.User.Role;
-import lombok.Data;
 
 /**
  * Data transfer object for {@code User}.
  *
- * <p>Lombok's {@link Data} annotation generates the standard getters, setters
- * and other utility methods at compile time.</p>
+ * <p>This class intentionally avoids Lombok to keep the project free from
+ * annotation processing requirements. Explicit getters and setters are
+ * provided so that the mapper and service layers can interact with the
+ * properties without relying on generated code.</p>
  */
-@Data
 public class UserDto {
     private Long id;
     private String username;
@@ -18,4 +18,26 @@ public class UserDto {
     private String lastName;
     private Role role;
     private boolean enabled;
+
+    // getters and setters
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+
+    public String getFirstName() { return firstName; }
+    public void setFirstName(String firstName) { this.firstName = firstName; }
+
+    public String getLastName() { return lastName; }
+    public void setLastName(String lastName) { this.lastName = lastName; }
+
+    public Role getRole() { return role; }
+    public void setRole(Role role) { this.role = role; }
+
+    public boolean isEnabled() { return enabled; }
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
 }

--- a/src/main/java/Neuroflow/backend/user/dto/UserPasswordUpdateRequest.java
+++ b/src/main/java/Neuroflow/backend/user/dto/UserPasswordUpdateRequest.java
@@ -2,15 +2,18 @@ package Neuroflow.backend.user.dto;
 
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
-import lombok.Data;
 
 /**
  * Request body used to update a user's password.
+ *
+ * <p>Explicit getters and setters are provided to avoid reliance on Lombok.</p>
  */
-@Data
 public class UserPasswordUpdateRequest {
     @NotBlank @Size(min=8)
     private String newPassword;
+
+    public String getNewPassword() { return newPassword; }
+    public void setNewPassword(String newPassword) { this.newPassword = newPassword; }
 }
 
 

--- a/src/main/java/Neuroflow/backend/user/dto/UserUpdateRequest.java
+++ b/src/main/java/Neuroflow/backend/user/dto/UserUpdateRequest.java
@@ -2,19 +2,33 @@ package Neuroflow.backend.user.dto;
 
 import jakarta.validation.constraints.*;
 import Neuroflow.backend.user.entity.User.Role;
-import lombok.Data;
 
 /**
  * Request body for updating an existing {@code User}.
  *
- * <p>Uses Lombok's {@link Data} annotation to provide the necessary getters and
- * setters.</p>
+ * <p>With Lombok removed, explicit accessor methods are provided for use by the
+ * service and mapper layers.</p>
  */
-@Data
 public class UserUpdateRequest {
     @NotBlank @Email private String email;
     @Size(max=80)    private String firstName;
     @Size(max=80)    private String lastName;
     private Role role;
     private boolean enabled;
+
+    // getters and setters
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+
+    public String getFirstName() { return firstName; }
+    public void setFirstName(String firstName) { this.firstName = firstName; }
+
+    public String getLastName() { return lastName; }
+    public void setLastName(String lastName) { this.lastName = lastName; }
+
+    public Role getRole() { return role; }
+    public void setRole(Role role) { this.role = role; }
+
+    public boolean isEnabled() { return enabled; }
+    public void setEnabled(boolean enabled) { this.enabled = enabled; }
 }


### PR DESCRIPTION
## Summary
- remove Lombok from user DTOs and provide explicit getters/setters
- document DTOs and avoid annotation-processing dependencies

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2a4835f488324871958b4626949ab