### PR TITLE
Add getters and setters for PedigreeUpsertRequest

### DIFF
--- a/src/main/java/Neuroflow/backend/pedigree/dto/PedigreeUpsertRequest.java
+++ b/src/main/java/Neuroflow/backend/pedigree/dto/PedigreeUpsertRequest.java
@@ -7,4 +7,20 @@ public class PedigreeUpsertRequest {
     @NotNull private Long patientId;
     @NotBlank private String data; // JSON string
     // getters/setters
+
+    public Long getPatientId() {
+        return patientId;
+    }
+
+    public void setPatientId(Long patientId) {
+        this.patientId = patientId;
+    }
+
+    public String getData() {
+        return data;
+    }
+
+    public void setData(String data) {
+        this.data = data;
+    }
 }


### PR DESCRIPTION
## Summary
- implement getters and setters for patientId and data in PedigreeUpsertRequest

## Testing
- `./mvnw -q test` *(fails: Non-resolvable parent POM... Could not transfer artifact, network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2ab2fb00c8324832bf78556900c01