### PR TITLE
Fix duplicate JPA repository definition

### DIFF
--- a/src/main/java/Neuroflow/backend/BackendApplication.java
+++ b/src/main/java/Neuroflow/backend/BackendApplication.java
@@ -6,10 +6,8 @@ import Neuroflow.backend.config.SecurityConfig;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
 
 @SpringBootApplication
-@EnableJpaRepositories
 @Import({DataBaseConfig.class, SecurityConfig.class})
 public class BackendApplication {
 


### PR DESCRIPTION
## Summary
- remove redundant `@EnableJpaRepositories` to prevent double registration of repositories

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2ac27eac88324abba7b810d9b7bcc