### PR TITLE
Add pedigree table schema and audit fields

### DIFF
--- a/src/main/java/Neuroflow/backend/pedigree/dto/PedigreeDto.java
+++ b/src/main/java/Neuroflow/backend/pedigree/dto/PedigreeDto.java
@@ -6,8 +6,11 @@ public class PedigreeDto {
     private Long id;
     private Long patientId;
     private String data;
-    private Instant updatedAt;
-    // getters and setters
+    private Long createdBy;
+    private Instant createdAt;
+    private Long lastModifiedBy;
+    private Instant lastModified;
+
     public Long getId() { return id; }
     public void setId(Long id) { this.id = id; }
 
@@ -17,6 +20,15 @@ public class PedigreeDto {
     public String getData() { return data; }
     public void setData(String data) { this.data = data; }
 
-    public Instant getUpdatedAt() { return updatedAt; }
-    public void setUpdatedAt(Instant updatedAt) { this.updatedAt = updatedAt; }
+    public Long getCreatedBy() { return createdBy; }
+    public void setCreatedBy(Long createdBy) { this.createdBy = createdBy; }
+
+    public Instant getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+
+    public Long getLastModifiedBy() { return lastModifiedBy; }
+    public void setLastModifiedBy(Long lastModifiedBy) { this.lastModifiedBy = lastModifiedBy; }
+
+    public Instant getLastModified() { return lastModified; }
+    public void setLastModified(Instant lastModified) { this.lastModified = lastModified; }
 }

--- a/src/main/java/Neuroflow/backend/pedigree/dto/PedigreeUpsertRequest.java
+++ b/src/main/java/Neuroflow/backend/pedigree/dto/PedigreeUpsertRequest.java
@@ -6,7 +6,8 @@ import jakarta.validation.constraints.NotBlank;
 public class PedigreeUpsertRequest {
     @NotNull private Long patientId;
     @NotBlank private String data; // JSON string
-    // getters/setters
+    @NotNull private Long createdBy;
+    @NotNull private Long lastModifiedBy;
 
     public Long getPatientId() {
         return patientId;
@@ -22,5 +23,21 @@ public class PedigreeUpsertRequest {
 
     public void setData(String data) {
         this.data = data;
+    }
+
+    public Long getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(Long createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public Long getLastModifiedBy() {
+        return lastModifiedBy;
+    }
+
+    public void setLastModifiedBy(Long lastModifiedBy) {
+        this.lastModifiedBy = lastModifiedBy;
     }
 }

--- a/src/main/java/Neuroflow/backend/pedigree/entity/Pedigree.java
+++ b/src/main/java/Neuroflow/backend/pedigree/entity/Pedigree.java
@@ -3,26 +3,63 @@ package Neuroflow.backend.pedigree.entity;
 import jakarta.persistence.*;
 import java.time.Instant;
 
-@Entity @Table(name = "pedigree")
+@Entity
+@Table(name = "pedigree")
 public class Pedigree {
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(name="patient_id", nullable=false)
+    @Column(name = "patient_id", nullable = false)
     private Long patientId;
 
-    @Lob @Column(nullable=false)
-    private String data; // JSON
+    @Column(columnDefinition = "jsonb", nullable = false)
+    private String data;
 
-    private Instant createdAt = Instant.now();
-    private Instant updatedAt = Instant.now();
+    @Column(name = "created_by", nullable = false, updatable = false)
+    private Long createdBy;
 
-    @PreUpdate void onUpdate(){ updatedAt = Instant.now(); }
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "last_modified", nullable = false)
+    private Instant lastModified;
+
+    @Column(name = "last_modified_by", nullable = false)
+    private Long lastModifiedBy;
+
+    @PrePersist
+    void onCreate() {
+        Instant now = Instant.now();
+        createdAt = now;
+        lastModified = now;
+    }
+
+    @PreUpdate
+    void onUpdate() {
+        lastModified = Instant.now();
+    }
 
     // getters/setters
-    public Long getId(){return id;} public void setId(Long id){this.id=id;}
-    public Long getPatientId(){return patientId;} public void setPatientId(Long p){this.patientId=p;}
-    public String getData(){return data;} public void setData(String d){this.data=d;}
-    public Instant getCreatedAt(){return createdAt;} public void setCreatedAt(Instant c){this.createdAt=c;}
-    public Instant getUpdatedAt(){return updatedAt;} public void setUpdatedAt(Instant u){this.updatedAt=u;}
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public Long getPatientId() { return patientId; }
+    public void setPatientId(Long patientId) { this.patientId = patientId; }
+
+    public String getData() { return data; }
+    public void setData(String data) { this.data = data; }
+
+    public Long getCreatedBy() { return createdBy; }
+    public void setCreatedBy(Long createdBy) { this.createdBy = createdBy; }
+
+    public Instant getCreatedAt() { return createdAt; }
+    public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+
+    public Instant getLastModified() { return lastModified; }
+    public void setLastModified(Instant lastModified) { this.lastModified = lastModified; }
+
+    public Long getLastModifiedBy() { return lastModifiedBy; }
+    public void setLastModifiedBy(Long lastModifiedBy) { this.lastModifiedBy = lastModifiedBy; }
 }

--- a/src/main/java/Neuroflow/backend/pedigree/mapper/PedigreeMapper.java
+++ b/src/main/java/Neuroflow/backend/pedigree/mapper/PedigreeMapper.java
@@ -8,8 +8,13 @@ import org.springframework.stereotype.Component;
 public class PedigreeMapper {
     public PedigreeDto toDto(Pedigree e){
         PedigreeDto d = new PedigreeDto();
-        d.setId(e.getId()); d.setPatientId(e.getPatientId()); d.setData(e.getData());
-        d.setUpdatedAt(e.getUpdatedAt());
+        d.setId(e.getId());
+        d.setPatientId(e.getPatientId());
+        d.setData(e.getData());
+        d.setCreatedBy(e.getCreatedBy());
+        d.setCreatedAt(e.getCreatedAt());
+        d.setLastModifiedBy(e.getLastModifiedBy());
+        d.setLastModified(e.getLastModified());
         return d;
     }
 }

--- a/src/main/java/Neuroflow/backend/pedigree/service/PedigreeServiceImpl.java
+++ b/src/main/java/Neuroflow/backend/pedigree/service/PedigreeServiceImpl.java
@@ -10,18 +10,31 @@ import org.springframework.web.server.ResponseStatusException;
 
 @Service
 public class PedigreeServiceImpl implements PedigreeService {
-    private final PedigreeRepository repo; private final PedigreeMapper mapper;
-    public PedigreeServiceImpl(PedigreeRepository r, PedigreeMapper m){ this.repo=r; this.mapper=m; }
+    private final PedigreeRepository repo;
+    private final PedigreeMapper mapper;
 
-    @Override public PedigreeDto getByPatientId(Long patientId) {
+    public PedigreeServiceImpl(PedigreeRepository r, PedigreeMapper m) {
+        this.repo = r;
+        this.mapper = m;
+        }
+
+    @Override
+    public PedigreeDto getByPatientId(Long patientId) {
         Pedigree e = repo.findByPatientId(patientId)
-                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Pedigree not found for patient " + patientId));
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "Pedigree not found for patient " + patientId));
         return mapper.toDto(e);
     }
 
-    @Override public PedigreeDto upsert(Long patientId, PedigreeUpsertRequest req) {
+    @Override
+    public PedigreeDto upsert(Long patientId, PedigreeUpsertRequest req) {
         Pedigree e = repo.findByPatientId(patientId).orElseGet(Pedigree::new);
-        e.setPatientId(patientId); e.setData(req.getData());
+        if (e.getId() == null) {
+            e.setCreatedBy(req.getCreatedBy());
+        }
+        e.setLastModifiedBy(req.getLastModifiedBy());
+        e.setPatientId(patientId);
+        e.setData(req.getData());
         return mapper.toDto(repo.save(e));
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,3 @@
 spring.application.name=backend
+spring.sql.init.mode=always
+spring.jpa.hibernate.ddl-auto=validate

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,55 @@
+-- idempotenza in sviluppo
+DROP TABLE IF EXISTS public.pedigree CASCADE;
+
+CREATE TABLE public.pedigree (
+                                 id               BIGINT NOT NULL,
+                                 patient_id       BIGINT NOT NULL,
+                                 data             JSONB  NOT NULL,
+                                 created_by       BIGINT NOT NULL,
+                                 created_at       TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT now(),
+                                 last_modified    TIMESTAMP WITHOUT TIME ZONE NOT NULL DEFAULT now(),
+                                 last_modified_by BIGINT NOT NULL
+);
+
+-- identity come nelle altre tabelle del tuo dump
+ALTER TABLE public.pedigree
+    ALTER COLUMN id ADD GENERATED ALWAYS AS IDENTITY (
+        SEQUENCE NAME public.pedigree_id_seq
+        START WITH 1 INCREMENT BY 1 NO MINVALUE NO MAXVALUE CACHE 1
+        );
+
+-- chiave primaria
+ALTER TABLE ONLY public.pedigree
+    ADD CONSTRAINT pedigree_pkey PRIMARY KEY (id);
+
+-- foreign keys (adattate a patient.id e users.user_id)
+ALTER TABLE ONLY public.pedigree
+    ADD CONSTRAINT fk_pedigree_patient
+        FOREIGN KEY (patient_id) REFERENCES public.patient(id) ON DELETE CASCADE;
+
+ALTER TABLE ONLY public.pedigree
+    ADD CONSTRAINT fk_pedigree_created_by
+        FOREIGN KEY (created_by) REFERENCES public.users(user_id) ON DELETE RESTRICT;
+
+ALTER TABLE ONLY public.pedigree
+    ADD CONSTRAINT fk_pedigree_last_modified_by
+        FOREIGN KEY (last_modified_by) REFERENCES public.users(user_id) ON DELETE RESTRICT;
+
+-- indici utili
+CREATE INDEX IF NOT EXISTS ix_pedigree_patient        ON public.pedigree(patient_id);
+CREATE INDEX IF NOT EXISTS ix_pedigree_created_by     ON public.pedigree(created_by);
+CREATE INDEX IF NOT EXISTS ix_pedigree_last_modified_by ON public.pedigree(last_modified_by);
+CREATE INDEX IF NOT EXISTS ix_pedigree_data_gin       ON public.pedigree USING gin(data);
+
+-- trigger per aggiornare last_modified ad ogni UPDATE
+CREATE OR REPLACE FUNCTION public.set_pedigree_last_modified()
+    RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+    NEW.last_modified := now();
+    RETURN NEW;
+END$$;
+
+DROP TRIGGER IF EXISTS trg_pedigree_set_last_modified ON public.pedigree;
+CREATE TRIGGER trg_pedigree_set_last_modified
+    BEFORE UPDATE ON public.pedigree
+    FOR EACH ROW EXECUTE FUNCTION public.set_pedigree_last_modified();


### PR DESCRIPTION
## Summary
- define full pedigree table DDL and trigger in `schema.sql`
- extend pedigree entity, DTO, mapper, and service to include audit fields
- enable running schema initialization on startup

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2d49bd46c8324b28057a98c610ef6