### PR TITLE
Fix report text mapping and provide schema

### DIFF
--- a/src/main/java/Neuroflow/backend/report/entity/Report.java
+++ b/src/main/java/Neuroflow/backend/report/entity/Report.java
@@ -26,12 +26,10 @@ public class Report {
     @Column(name = "closing_date")
     private LocalDate closingDate;
 
-    @Lob
-    @Column(nullable = false)
+    @Column(columnDefinition = "TEXT", nullable = false)
     private String diagnosis;
 
-    @Lob
-    @Column(name = "project_course", nullable = false)
+    @Column(name = "project_course", columnDefinition = "TEXT", nullable = false)
     private String projectCourse;
 
     public Long getId() {

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,14 @@
+-- REPORT
+CREATE TABLE IF NOT EXISTS report (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    treatment_path_id BIGINT NOT NULL,
+    patient_id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL,
+    opening_date DATE NOT NULL,
+    closing_date DATE,
+    diagnosis TEXT NOT NULL,
+    project_course TEXT NOT NULL,
+    CONSTRAINT fk_report_treatment FOREIGN KEY (treatment_path_id) REFERENCES treatment_path(id) ON DELETE CASCADE,
+    CONSTRAINT fk_report_patient FOREIGN KEY (patient_id) REFERENCES patient(id) ON DELETE CASCADE,
+    CONSTRAINT fk_report_user FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
+);


### PR DESCRIPTION
## Summary
- map report diagnosis and project course as TEXT columns
- add SQL schema for report table

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2decaef30832480c0eeb37b59310f