### PR TITLE
fix: align treatment path schema

### DIFF
--- a/src/main/java/Neuroflow/backend/treatmentpath/dto/TreatmentPathCreateRequest.java
+++ b/src/main/java/Neuroflow/backend/treatmentpath/dto/TreatmentPathCreateRequest.java
@@ -16,10 +16,46 @@ public class TreatmentPathCreateRequest {
     @NotNull
     private Long patientId;
 
-    private Long reportId;
     private Long userId;
 
-    // getters & setters
-    // ...
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public LocalDate getDateStart() {
+        return dateStart;
+    }
+
+    public void setDateStart(LocalDate dateStart) {
+        this.dateStart = dateStart;
+    }
+
+    public LocalDate getDateEnd() {
+        return dateEnd;
+    }
+
+    public void setDateEnd(LocalDate dateEnd) {
+        this.dateEnd = dateEnd;
+    }
+
+    public Long getPatientId() {
+        return patientId;
+    }
+
+    public void setPatientId(Long patientId) {
+        this.patientId = patientId;
+    }
+
+    public Long getUserId() {
+        return userId;
+    }
+
+    public void setUserId(Long userId) {
+        this.userId = userId;
+    }
 }
 

--- a/src/main/java/Neuroflow/backend/treatmentpath/dto/TreatmentPathDto.java
+++ b/src/main/java/Neuroflow/backend/treatmentpath/dto/TreatmentPathDto.java
@@ -9,7 +9,6 @@ public class TreatmentPathDto {
     private LocalDate dateStart;
     private LocalDate dateEnd;
     private Long patientId;
-    private Long reportId;
     private Long userId;
 
     public Long getId() {
@@ -50,14 +49,6 @@ public class TreatmentPathDto {
 
     public void setPatientId(Long patientId) {
         this.patientId = patientId;
-    }
-
-    public Long getReportId() {
-        return reportId;
-    }
-
-    public void setReportId(Long reportId) {
-        this.reportId = reportId;
     }
 
     public Long getUserId() {

--- a/src/main/java/Neuroflow/backend/treatmentpath/dto/TreatmentPathUpdateRequest.java
+++ b/src/main/java/Neuroflow/backend/treatmentpath/dto/TreatmentPathUpdateRequest.java
@@ -17,8 +17,6 @@ public class TreatmentPathUpdateRequest {
     @NotNull
     private Long patientId;
 
-    private Long reportId;
-
     private Long userId;
 
     public String getType() {
@@ -51,14 +49,6 @@ public class TreatmentPathUpdateRequest {
 
     public void setPatientId(Long patientId) {
         this.patientId = patientId;
-    }
-
-    public Long getReportId() {
-        return reportId;
-    }
-
-    public void setReportId(Long reportId) {
-        this.reportId = reportId;
     }
 
     public Long getUserId() {

--- a/src/main/java/Neuroflow/backend/treatmentpath/entity/TreatmentPath.java
+++ b/src/main/java/Neuroflow/backend/treatmentpath/entity/TreatmentPath.java
@@ -23,10 +23,7 @@ public class TreatmentPath {
     @Column(name = "patient_id", nullable = false)
     private Long patientId;
 
-    @Column(name = "report_id")
-    private Long reportId;
-
-    @Column(name = "user_id")
+    @Column(name = "user_id", nullable = false)
     private Long userId;
 
     public Long getId() { return id; }
@@ -43,9 +40,6 @@ public class TreatmentPath {
 
     public Long getPatientId() { return patientId; }
     public void setPatientId(Long patientId) { this.patientId = patientId; }
-
-    public Long getReportId() { return reportId; }
-    public void setReportId(Long reportId) { this.reportId = reportId; }
 
     public Long getUserId() { return userId; }
     public void setUserId(Long userId) { this.userId = userId; }

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,3 +1,15 @@
+-- TREATMENT_PATH
+CREATE TABLE IF NOT EXISTS treatment_path (
+    id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
+    type VARCHAR(255) NOT NULL,
+    date_start DATE NOT NULL,
+    date_end DATE,
+    patient_id BIGINT NOT NULL,
+    user_id BIGINT NOT NULL,
+    CONSTRAINT fk_treatment_patient FOREIGN KEY (patient_id) REFERENCES patient(id) ON DELETE CASCADE,
+    CONSTRAINT fk_treatment_user FOREIGN KEY (user_id) REFERENCES users(user_id) ON DELETE CASCADE
+);
+
 -- REPORT
 CREATE TABLE IF NOT EXISTS report (
     id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,


### PR DESCRIPTION
## Summary
- drop report reference from TreatmentPath entity and DTOs
- expose getters/setters in TreatmentPathCreateRequest
- define treatment_path table in schema.sql

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e0e74b708324a76fc2db9f26da24