### PR TITLE
Align User entity with SQL schema

### DIFF
--- a/src/main/java/Neuroflow/backend/user/dto/UserCreateRequest.java
+++ b/src/main/java/Neuroflow/backend/user/dto/UserCreateRequest.java
@@ -1,7 +1,7 @@
 package Neuroflow.backend.user.dto;
 
 import jakarta.validation.constraints.*;
-import Neuroflow.backend.user.entity.User.Role;
+import java.time.LocalDate;
 
 /**
  * Request body for creating a {@code User}.
@@ -10,13 +10,13 @@ import Neuroflow.backend.user.entity.User.Role;
  * and setters are implemented to expose the request properties.</p>
  */
 public class UserCreateRequest {
-    @NotBlank @Size(max=64)  private String username;
+    @NotBlank @Size(max=255) private String username;
     @NotBlank @Email         private String email;
     @NotBlank @Size(min=8)   private String password; // in chiaro SOLO qui, verrà hashata nel service
-    @Size(max=80)            private String firstName;
-    @Size(max=80)            private String lastName;
-    private Role role = Role.USER;
-    private boolean enabled = true;
+    @NotBlank @Size(max=255) private String firstName;
+    @NotBlank @Size(max=255) private String lastName;
+    private LocalDate dateBirth;
+    @Size(max=255)           private String address;
 
     // getters and setters
     public String getUsername() { return username; }
@@ -34,9 +34,9 @@ public class UserCreateRequest {
     public String getLastName() { return lastName; }
     public void setLastName(String lastName) { this.lastName = lastName; }
 
-    public Role getRole() { return role; }
-    public void setRole(Role role) { this.role = role; }
+    public LocalDate getDateBirth() { return dateBirth; }
+    public void setDateBirth(LocalDate dateBirth) { this.dateBirth = dateBirth; }
 
-    public boolean isEnabled() { return enabled; }
-    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+    public String getAddress() { return address; }
+    public void setAddress(String address) { this.address = address; }
 }

--- a/src/main/java/Neuroflow/backend/user/dto/UserDto.java
+++ b/src/main/java/Neuroflow/backend/user/dto/UserDto.java
@@ -1,6 +1,6 @@
 package Neuroflow.backend.user.dto;
 
-import Neuroflow.backend.user.entity.User.Role;
+import java.time.LocalDate;
 
 /**
  * Data transfer object for {@code User}.
@@ -16,8 +16,8 @@ public class UserDto {
     private String email;
     private String firstName;
     private String lastName;
-    private Role role;
-    private boolean enabled;
+    private LocalDate dateBirth;
+    private String address;
 
     // getters and setters
     public Long getId() { return id; }
@@ -35,9 +35,9 @@ public class UserDto {
     public String getLastName() { return lastName; }
     public void setLastName(String lastName) { this.lastName = lastName; }
 
-    public Role getRole() { return role; }
-    public void setRole(Role role) { this.role = role; }
+    public LocalDate getDateBirth() { return dateBirth; }
+    public void setDateBirth(LocalDate dateBirth) { this.dateBirth = dateBirth; }
 
-    public boolean isEnabled() { return enabled; }
-    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+    public String getAddress() { return address; }
+    public void setAddress(String address) { this.address = address; }
 }

--- a/src/main/java/Neuroflow/backend/user/dto/UserUpdateRequest.java
+++ b/src/main/java/Neuroflow/backend/user/dto/UserUpdateRequest.java
@@ -1,7 +1,7 @@
 package Neuroflow.backend.user.dto;
 
 import jakarta.validation.constraints.*;
-import Neuroflow.backend.user.entity.User.Role;
+import java.time.LocalDate;
 
 /**
  * Request body for updating an existing {@code User}.
@@ -11,10 +11,10 @@ import Neuroflow.backend.user.entity.User.Role;
  */
 public class UserUpdateRequest {
     @NotBlank @Email private String email;
-    @Size(max=80)    private String firstName;
-    @Size(max=80)    private String lastName;
-    private Role role;
-    private boolean enabled;
+    @NotBlank @Size(max=255) private String firstName;
+    @NotBlank @Size(max=255) private String lastName;
+    private LocalDate dateBirth;
+    @Size(max=255) private String address;
 
     // getters and setters
     public String getEmail() { return email; }
@@ -26,9 +26,9 @@ public class UserUpdateRequest {
     public String getLastName() { return lastName; }
     public void setLastName(String lastName) { this.lastName = lastName; }
 
-    public Role getRole() { return role; }
-    public void setRole(Role role) { this.role = role; }
+    public LocalDate getDateBirth() { return dateBirth; }
+    public void setDateBirth(LocalDate dateBirth) { this.dateBirth = dateBirth; }
 
-    public boolean isEnabled() { return enabled; }
-    public void setEnabled(boolean enabled) { this.enabled = enabled; }
+    public String getAddress() { return address; }
+    public void setAddress(String address) { this.address = address; }
 }

--- a/src/main/java/Neuroflow/backend/user/entity/User.java
+++ b/src/main/java/Neuroflow/backend/user/entity/User.java
@@ -1,6 +1,7 @@
 package Neuroflow.backend.user.entity;
 
 import jakarta.persistence.*;
+import java.time.LocalDate;
 
 @Entity
 @Table(name = "users",
@@ -10,37 +11,54 @@ import jakarta.persistence.*;
         })
 public class User {
 
-    public enum Role { ADMIN, USER }
-
-    @Id @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "user_id")
     private Long id;
 
-    @Column(nullable = false, length = 64)
+    @Column(nullable = false, length = 255)
     private String username;
 
-    @Column(nullable = false, length = 255)
-    private String email;
-
-    @Column(name = "password_hash", nullable = false, length = 255)
+    @Column(name = "password", nullable = false)
     private String passwordHash;
 
-    @Column(length = 80) private String firstName;
-    @Column(length = 80) private String lastName;
-
-    @Enumerated(EnumType.STRING)
-    @Column(nullable = false, length = 16)
-    private Role role = Role.USER;
-
     @Column(nullable = false)
-    private boolean enabled = true;
+    private String email;
+
+    @Column(name = "first_name", nullable = false, length = 255)
+    private String firstName;
+
+    @Column(name = "last_name", nullable = false, length = 255)
+    private String lastName;
+
+    @Column(name = "date_birth")
+    private LocalDate dateBirth;
+
+    @Column(length = 255)
+    private String address;
 
     // getters/setters
-    public Long getId() { return id; } public void setId(Long id) { this.id = id; }
-    public String getUsername() { return username; } public void setUsername(String u) { this.username = u; }
-    public String getEmail() { return email; } public void setEmail(String e) { this.email = e; }
-    public String getPasswordHash() { return passwordHash; } public void setPasswordHash(String p) { this.passwordHash = p; }
-    public String getFirstName() { return firstName; } public void setFirstName(String f) { this.firstName = f; }
-    public String getLastName() { return lastName; } public void setLastName(String l) { this.lastName = l; }
-    public Role getRole() { return role; } public void setRole(Role r) { this.role = r; }
-    public boolean isEnabled() { return enabled; } public void setEnabled(boolean e) { this.enabled = e; }
+    public Long getId() { return id; }
+    public void setId(Long id) { this.id = id; }
+
+    public String getUsername() { return username; }
+    public void setUsername(String username) { this.username = username; }
+
+    public String getPasswordHash() { return passwordHash; }
+    public void setPasswordHash(String passwordHash) { this.passwordHash = passwordHash; }
+
+    public String getEmail() { return email; }
+    public void setEmail(String email) { this.email = email; }
+
+    public String getFirstName() { return firstName; }
+    public void setFirstName(String firstName) { this.firstName = firstName; }
+
+    public String getLastName() { return lastName; }
+    public void setLastName(String lastName) { this.lastName = lastName; }
+
+    public LocalDate getDateBirth() { return dateBirth; }
+    public void setDateBirth(LocalDate dateBirth) { this.dateBirth = dateBirth; }
+
+    public String getAddress() { return address; }
+    public void setAddress(String address) { this.address = address; }
 }

--- a/src/main/java/Neuroflow/backend/user/mapper/UserMapper.java
+++ b/src/main/java/Neuroflow/backend/user/mapper/UserMapper.java
@@ -15,8 +15,8 @@ public class UserMapper {
         d.setEmail(e.getEmail());
         d.setFirstName(e.getFirstName());
         d.setLastName(e.getLastName());
-        d.setRole(e.getRole());
-        d.setEnabled(e.isEnabled());
+        d.setDateBirth(e.getDateBirth());
+        d.setAddress(e.getAddress());
         return d;
     }
 
@@ -26,8 +26,8 @@ public class UserMapper {
         e.setEmail(r.getEmail());
         e.setFirstName(r.getFirstName());
         e.setLastName(r.getLastName());
-        e.setRole(r.getRole());
-        e.setEnabled(r.isEnabled());
+        e.setDateBirth(r.getDateBirth());
+        e.setAddress(r.getAddress());
         // passwordHash viene settata nel Service
         return e;
     }
@@ -36,7 +36,7 @@ public class UserMapper {
         e.setEmail(r.getEmail());
         e.setFirstName(r.getFirstName());
         e.setLastName(r.getLastName());
-        if (r.getRole()!=null) e.setRole(r.getRole());
-        e.setEnabled(r.isEnabled());
+        e.setDateBirth(r.getDateBirth());
+        e.setAddress(r.getAddress());
     }
 }


### PR DESCRIPTION
## Summary
- Map `User` entity to existing `users` table with `user_id`, `password`, and other fields from schema
- Drop unused role and enabled fields across DTOs and mapper
- Extend user DTOs to include date of birth and address

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e2203f8c8324b5254b4c756c75c1