### PR TITLE
Add authentication endpoint for user login

### DIFF
--- a/src/main/java/Neuroflow/backend/user/controller/AuthController.java
+++ b/src/main/java/Neuroflow/backend/user/controller/AuthController.java
@@ -1,0 +1,19 @@
+package Neuroflow.backend.user.controller;
+
+import Neuroflow.backend.user.dto.AuthResponse;
+import Neuroflow.backend.user.dto.LoginRequest;
+import Neuroflow.backend.user.service.UserService;
+import jakarta.validation.Valid;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+public class AuthController {
+    private final UserService service;
+    public AuthController(UserService service) { this.service = service; }
+
+    @PostMapping("/signin")
+    public AuthResponse login(@Valid @RequestBody LoginRequest req) {
+        return service.login(req);
+    }
+}

--- a/src/main/java/Neuroflow/backend/user/dto/AuthResponse.java
+++ b/src/main/java/Neuroflow/backend/user/dto/AuthResponse.java
@@ -1,0 +1,39 @@
+package Neuroflow.backend.user.dto;
+
+public class AuthResponse {
+    private boolean success;
+    private String message;
+    private UserDto user;
+
+    public AuthResponse() {}
+
+    public AuthResponse(boolean success, String message, UserDto user) {
+        this.success = success;
+        this.message = message;
+        this.user = user;
+    }
+
+    public boolean isSuccess() {
+        return success;
+    }
+
+    public void setSuccess(boolean success) {
+        this.success = success;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public UserDto getUser() {
+        return user;
+    }
+
+    public void setUser(UserDto user) {
+        this.user = user;
+    }
+}

--- a/src/main/java/Neuroflow/backend/user/dto/LoginRequest.java
+++ b/src/main/java/Neuroflow/backend/user/dto/LoginRequest.java
@@ -1,0 +1,26 @@
+package Neuroflow.backend.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public class LoginRequest {
+    @NotBlank
+    private String username;
+    @NotBlank
+    private String password;
+
+    public String getUsername() {
+        return username;
+    }
+
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    public String getPassword() {
+        return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
+    }
+}

--- a/src/main/java/Neuroflow/backend/user/service/UserService.java
+++ b/src/main/java/Neuroflow/backend/user/service/UserService.java
@@ -11,4 +11,5 @@ public interface UserService {
     UserDto update(Long id, UserUpdateRequest req);
     void delete(Long id);
     void changePassword(Long id, UserPasswordUpdateRequest req);
+    AuthResponse login(LoginRequest req);
 }

--- a/src/main/java/Neuroflow/backend/user/service/UserServiceImpl.java
+++ b/src/main/java/Neuroflow/backend/user/service/UserServiceImpl.java
@@ -56,5 +56,14 @@ public class UserServiceImpl implements UserService {
         e.setPasswordHash(passwordEncoder.encode(r.getNewPassword()));
         repo.save(e);
     }
+
+    @Override
+    public AuthResponse login(LoginRequest req) {
+        User u = repo.findByUsername(req.getUsername()).orElse(null);
+        if (u == null || !passwordEncoder.matches(req.getPassword(), u.getPasswordHash())) {
+            return new AuthResponse(false, "Invalid credentials", null);
+        }
+        return new AuthResponse(true, "Login successful", mapper.toDto(u));
+    }
 }
 


### PR DESCRIPTION
## Summary
- add `LoginRequest` and `AuthResponse` DTOs for authentication
- extend `UserService` with `login` method and implementation
- introduce `/api/v1/auth/signin` endpoint in new `AuthController`

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e687c4088324bb1a48fe66edbc8d