### PR TITLE
Use NoOp password encoder for dev profile

### DIFF
--- a/src/main/java/Neuroflow/backend/config/SecurityConfig.java
+++ b/src/main/java/Neuroflow/backend/config/SecurityConfig.java
@@ -2,14 +2,23 @@ package Neuroflow.backend.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.NoOpPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
 public class SecurityConfig {
 
     @Bean
+    @Profile("!dev")
     public PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
+    }
+
+    @Bean
+    @Profile("dev")
+    public PasswordEncoder devPasswordEncoder() {
+        return NoOpPasswordEncoder.getInstance();
     }
 }


### PR DESCRIPTION
## Summary
- Use BCryptPasswordEncoder for all profiles except `dev`
- Provide `NoOpPasswordEncoder` when running with `dev` profile to simplify local development

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2eafed6fc83248223d045dc123655