### PR TITLE
Add frontend patient view endpoint

### DIFF
--- a/src/main/java/Neuroflow/backend/patient/controller/PatientController.java
+++ b/src/main/java/Neuroflow/backend/patient/controller/PatientController.java
@@ -14,6 +14,7 @@ public class PatientController {
     public PatientController(PatientService service) { this.service = service; }
 
     @GetMapping public Page<PatientDto> list(Pageable p) { return service.list(p); }
+    @GetMapping("/frontend") public Page<PatientFrontendDto> listFrontend(Pageable p) { return service.listFrontend(p); }
     @GetMapping("/{id}") public PatientDto get(@PathVariable Long id) { return service.get(id); }
     @PostMapping public PatientDto create(@Valid @RequestBody PatientCreateRequest r) { return service.create(r); }
     @PutMapping("/{id}") public PatientDto update(@PathVariable Long id, @Valid @RequestBody PatientUpdateRequest r) { return service.update(id, r); }

--- a/src/main/java/Neuroflow/backend/patient/dto/PatientCreateRequest.java
+++ b/src/main/java/Neuroflow/backend/patient/dto/PatientCreateRequest.java
@@ -23,6 +23,7 @@ public class PatientCreateRequest {
     private boolean caregiver;
     @NotBlank private String phoneNumber;
     @Email private String mail;
+    private String fiscalCode;
 
     public String getFirstName() {
         return firstName;
@@ -126,6 +127,14 @@ public class PatientCreateRequest {
 
     public void setMail(String mail) {
         this.mail = mail;
+    }
+
+    public String getFiscalCode() {
+        return fiscalCode;
+    }
+
+    public void setFiscalCode(String fiscalCode) {
+        this.fiscalCode = fiscalCode;
     }
 }
 

--- a/src/main/java/Neuroflow/backend/patient/dto/PatientDto.java
+++ b/src/main/java/Neuroflow/backend/patient/dto/PatientDto.java
@@ -24,6 +24,7 @@ public class PatientDto {
     private boolean caregiver;
     private String phoneNumber;
     private String mail;
+    private String fiscalCode;
 
     public Long getId() {
         return id;
@@ -135,6 +136,14 @@ public class PatientDto {
 
     public void setMail(String mail) {
         this.mail = mail;
+    }
+
+    public String getFiscalCode() {
+        return fiscalCode;
+    }
+
+    public void setFiscalCode(String fiscalCode) {
+        this.fiscalCode = fiscalCode;
     }
 }
 

--- a/src/main/java/Neuroflow/backend/patient/dto/PatientFrontendDto.java
+++ b/src/main/java/Neuroflow/backend/patient/dto/PatientFrontendDto.java
@@ -1,0 +1,91 @@
+package Neuroflow.backend.patient.dto;
+
+import java.time.LocalDate;
+
+/**
+ * Simplified patient view intended for frontend consumption.
+ * Contains only the fields required by the UI.
+ */
+public class PatientFrontendDto {
+    private Long id;
+    private String firstName;
+    private String lastName;
+    private LocalDate dateOfBirth;
+    private String email;
+    private String phone;
+    private String address;
+    private String gender;
+    private String fiscalCode;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getFirstName() {
+        return firstName;
+    }
+
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
+    public String getLastName() {
+        return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
+    }
+
+    public LocalDate getDateOfBirth() {
+        return dateOfBirth;
+    }
+
+    public void setDateOfBirth(LocalDate dateOfBirth) {
+        this.dateOfBirth = dateOfBirth;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+
+    public String getPhone() {
+        return phone;
+    }
+
+    public void setPhone(String phone) {
+        this.phone = phone;
+    }
+
+    public String getAddress() {
+        return address;
+    }
+
+    public void setAddress(String address) {
+        this.address = address;
+    }
+
+    public String getGender() {
+        return gender;
+    }
+
+    public void setGender(String gender) {
+        this.gender = gender;
+    }
+
+    public String getFiscalCode() {
+        return fiscalCode;
+    }
+
+    public void setFiscalCode(String fiscalCode) {
+        this.fiscalCode = fiscalCode;
+    }
+}

--- a/src/main/java/Neuroflow/backend/patient/dto/PatientUpdateRequest.java
+++ b/src/main/java/Neuroflow/backend/patient/dto/PatientUpdateRequest.java
@@ -22,6 +22,7 @@ public class PatientUpdateRequest {
     private boolean caregiver;
     @NotBlank private String phoneNumber;
     @Email private String mail;
+    private String fiscalCode;
 
     public String getFirstName() {
         return firstName;
@@ -125,6 +126,14 @@ public class PatientUpdateRequest {
 
     public void setMail(String mail) {
         this.mail = mail;
+    }
+
+    public String getFiscalCode() {
+        return fiscalCode;
+    }
+
+    public void setFiscalCode(String fiscalCode) {
+        this.fiscalCode = fiscalCode;
     }
 }
 

--- a/src/main/java/Neuroflow/backend/patient/entity/Patient.java
+++ b/src/main/java/Neuroflow/backend/patient/entity/Patient.java
@@ -49,6 +49,9 @@ public class Patient {
     @Column(name = "mail")
     private String mail;
 
+    @Column(name = "fiscal_code")
+    private String fiscalCode;
+
     public Patient() {}
 
     public Patient(String firstName,
@@ -63,7 +66,8 @@ public class Patient {
                    String maritalStatus,
                    boolean caregiver,
                    String phoneNumber,
-                   String mail) {
+                   String mail,
+                   String fiscalCode) {
         this.firstName = firstName;
         this.lastName = lastName;
         this.dateBirth = Date.valueOf(dateBirth);
@@ -77,6 +81,7 @@ public class Patient {
         this.caregiver = caregiver;
         this.phoneNumber = phoneNumber;
         this.mail = mail;
+        this.fiscalCode = fiscalCode;
     }
 
     public Patient(Long id,
@@ -92,9 +97,10 @@ public class Patient {
                    String maritalStatus,
                    boolean caregiver,
                    String phoneNumber,
-                   String mail) {
+                   String mail,
+                   String fiscalCode) {
         this(firstName, lastName, dateBirth, cityBirth, address, gender, occupation,
-             nationality, studyYears, maritalStatus, caregiver, phoneNumber, mail);
+             nationality, studyYears, maritalStatus, caregiver, phoneNumber, mail, fiscalCode);
         this.id = id;
     }
 
@@ -208,6 +214,14 @@ public class Patient {
 
     public void setMail(String mail) {
         this.mail = mail;
+    }
+
+    public String getFiscalCode() {
+        return fiscalCode;
+    }
+
+    public void setFiscalCode(String fiscalCode) {
+        this.fiscalCode = fiscalCode;
     }
 }
 

--- a/src/main/java/Neuroflow/backend/patient/mapper/PatientMapper.java
+++ b/src/main/java/Neuroflow/backend/patient/mapper/PatientMapper.java
@@ -24,6 +24,22 @@ public class PatientMapper {
         d.setCaregiver(e.isCaregiver());
         d.setPhoneNumber(e.getPhoneNumber());
         d.setMail(e.getMail());
+        d.setFiscalCode(e.getFiscalCode());
+        return d;
+    }
+
+    public PatientFrontendDto toFrontendDto(Patient e) {
+        if (e == null) return null;
+        PatientFrontendDto d = new PatientFrontendDto();
+        d.setId(e.getId());
+        d.setFirstName(e.getFirstName());
+        d.setLastName(e.getLastName());
+        d.setDateOfBirth(e.getDateBirth().toLocalDate());
+        d.setEmail(e.getMail());
+        d.setPhone(e.getPhoneNumber());
+        d.setAddress(e.getAddress());
+        d.setGender(e.getGender());
+        d.setFiscalCode(e.getFiscalCode());
         return d;
     }
 
@@ -42,6 +58,7 @@ public class PatientMapper {
         e.setCaregiver(r.isCaregiver());
         e.setPhoneNumber(r.getPhoneNumber());
         e.setMail(r.getMail());
+        e.setFiscalCode(r.getFiscalCode());
     }
 
     public void updateEntity(PatientCreateRequest r, Patient e) {
@@ -59,6 +76,7 @@ public class PatientMapper {
         e.setCaregiver(r.isCaregiver());
         e.setPhoneNumber(r.getPhoneNumber());
         e.setMail(r.getMail());
+        e.setFiscalCode(r.getFiscalCode());
     }
 
     public Patient toEntity(PatientCreateRequest r) {

--- a/src/main/java/Neuroflow/backend/patient/service/PatientService.java
+++ b/src/main/java/Neuroflow/backend/patient/service/PatientService.java
@@ -10,4 +10,6 @@ public interface PatientService {
     PatientDto create(PatientCreateRequest req);
     PatientDto update(Long id, PatientUpdateRequest req);
     void delete(Long id);
+
+    Page<PatientFrontendDto> listFrontend(Pageable pageable);
 }

--- a/src/main/java/Neuroflow/backend/patient/service/PatientServiceImpl.java
+++ b/src/main/java/Neuroflow/backend/patient/service/PatientServiceImpl.java
@@ -23,6 +23,10 @@ public class PatientServiceImpl implements PatientService {
         return repo.findAll(pageable).map(mapper::toDto);
     }
 
+    @Override public Page<PatientFrontendDto> listFrontend(Pageable pageable) {
+        return repo.findAll(pageable).map(mapper::toFrontendDto);
+    }
+
     @Override public PatientDto get(Long id) {
         Patient e = repo.findById(id).orElseThrow(
                 () -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Patient not found: " + id));


### PR DESCRIPTION
## Summary
- expose `/api/v1/patients/frontend` endpoint returning simplified patient info
- include fiscal code in patient entity and DTOs
- map new PatientFrontendDto for frontend consumption

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM, network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c7d887155c83249e83856b05e7a9bb