### PR TITLE
Add API v1 context path prefix

### DIFF
--- a/src/main/java/Neuroflow/backend/config/WebConfig.java
+++ b/src/main/java/Neuroflow/backend/config/WebConfig.java
@@ -46,7 +46,7 @@ public class WebConfig implements WebMvcConfigurer {
     //NEW METHOD need to understand what to use
     @Override
     public void addCorsMappings(CorsRegistry registry) {
-        registry.addMapping("/api/v1/**")
+        registry.addMapping("/**")
             // metti qui tutti i tuoi frontend (dev e prod)
             .allowedOriginPatterns(
                     "http://localhost:4200",

--- a/src/main/java/Neuroflow/backend/patient/controller/PatientController.java
+++ b/src/main/java/Neuroflow/backend/patient/controller/PatientController.java
@@ -8,7 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/v1/patients")
+@RequestMapping("/patients")
 public class PatientController {
     private final PatientService service;
     public PatientController(PatientService service) { this.service = service; }

--- a/src/main/java/Neuroflow/backend/pedigree/controller/PedigreeController.java
+++ b/src/main/java/Neuroflow/backend/pedigree/controller/PedigreeController.java
@@ -6,7 +6,7 @@ import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/v1/patients/{patientId}/pedigree")
+@RequestMapping("/patients/{patientId}/pedigree")
 public class PedigreeController {
     private final PedigreeService service;
     public PedigreeController(PedigreeService s){ this.service=s; }

--- a/src/main/java/Neuroflow/backend/report/controller/ReportController.java
+++ b/src/main/java/Neuroflow/backend/report/controller/ReportController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.Optional;
 
 @RestController
-@RequestMapping("/api/v1/reports")
+@RequestMapping("/reports")
 public class ReportController {
 
     private final ReportService service;

--- a/src/main/java/Neuroflow/backend/treatmentpath/controller/TreatmentPathController.java
+++ b/src/main/java/Neuroflow/backend/treatmentpath/controller/TreatmentPathController.java
@@ -10,7 +10,7 @@ import org.springframework.web.bind.annotation.*;
 import java.util.Optional;
 
 @RestController
-@RequestMapping("/api/v1/treatment-paths")
+@RequestMapping("/treatment-paths")
 public class TreatmentPathController {
 
     private final TreatmentPathService service;

--- a/src/main/java/Neuroflow/backend/user/controller/AuthController.java
+++ b/src/main/java/Neuroflow/backend/user/controller/AuthController.java
@@ -7,7 +7,7 @@ import jakarta.validation.Valid;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/v1/auth")
+@RequestMapping("/auth")
 public class AuthController {
     private final UserService service;
     public AuthController(UserService service) { this.service = service; }

--- a/src/main/java/Neuroflow/backend/user/controller/UserController.java
+++ b/src/main/java/Neuroflow/backend/user/controller/UserController.java
@@ -8,7 +8,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/api/v1/users")
+@RequestMapping("/users")
 public class UserController {
 
     private final UserService service;

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,3 +1,4 @@
 spring.application.name=backend
 spring.sql.init.mode=always
 spring.jpa.hibernate.ddl-auto=update
+server.servlet.context-path=/api/v1


### PR DESCRIPTION
## Summary
- set the servlet context path to /api/v1 for consistent API versioning
- adjust controller request mappings to rely on the shared versioned context path
- update CORS configuration to match the new base path

## Testing
- ./mvnw test *(fails: PostgreSQL is not available in the environment during tests)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692567bea7148324b42c13d050d1bd8a)