### PR TITLE
Add legacy treatment list endpoint

### DIFF
--- a/src/main/java/Neuroflow/backend/legacy/LegacyListController.java
+++ b/src/main/java/Neuroflow/backend/legacy/LegacyListController.java
@@ -4,6 +4,8 @@ import Neuroflow.backend.patient.dto.PatientDto;
 import Neuroflow.backend.patient.service.PatientService;
 import Neuroflow.backend.report.dto.ReportDto;
 import Neuroflow.backend.report.service.ReportService;
+import Neuroflow.backend.treatmentpath.dto.TreatmentPathDto;
+import Neuroflow.backend.treatmentpath.service.TreatmentPathService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -19,10 +21,13 @@ public class LegacyListController {
 
     private final PatientService patientService;
     private final ReportService reportService;
+    private final TreatmentPathService treatmentPathService;
 
-    public LegacyListController(PatientService patientService, ReportService reportService) {
+    public LegacyListController(PatientService patientService, ReportService reportService,
+                                TreatmentPathService treatmentPathService) {
         this.patientService = patientService;
         this.reportService = reportService;
+        this.treatmentPathService = treatmentPathService;
     }
 
     @GetMapping("/listpatient")
@@ -36,5 +41,11 @@ public class LegacyListController {
                                        @RequestParam Optional<Long> treatmentPathId,
                                        @RequestParam Optional<Long> userId) {
         return reportService.list(pageable, patientId, treatmentPathId, userId);
+    }
+
+    @GetMapping("/treatmentlist")
+    public Page<TreatmentPathDto> listTreatmentPaths(Pageable pageable,
+                                                    @RequestParam Optional<Long> patientId) {
+        return treatmentPathService.list(pageable, patientId);
     }
 }


### PR DESCRIPTION
## Summary
- inject treatment path service into the legacy list controller
- expose a /treatmentlist endpoint returning treatment paths filtered by patient when provided

## Testing
- mvn test *(fails: database connection to localhost:5432 refused during context load)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69256ddb8cd08324a5b18a1f59c909ee)