### PR TITLE
Add legacy treatment list endpoint

### DIFF
--- a/src/main/java/Neuroflow/backend/legacy/LegacyListController.java
+++ b/src/main/java/Neuroflow/backend/legacy/LegacyListController.java
@@ -4,8 +4,6 @@ import Neuroflow.backend.patient.dto.PatientDto;
 import Neuroflow.backend.patient.service.PatientService;
 import Neuroflow.backend.report.dto.ReportDto;
 import Neuroflow.backend.report.service.ReportService;
-import Neuroflow.backend.treatmentpath.dto.TreatmentPathDto;
-import Neuroflow.backend.treatmentpath.service.TreatmentPathService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -21,13 +19,10 @@ public class LegacyListController {
 
     private final PatientService patientService;
     private final ReportService reportService;
-    private final TreatmentPathService treatmentPathService;
 
-    public LegacyListController(PatientService patientService, ReportService reportService,
-                                TreatmentPathService treatmentPathService) {
+    public LegacyListController(PatientService patientService, ReportService reportService) {
         this.patientService = patientService;
         this.reportService = reportService;
-        this.treatmentPathService = treatmentPathService;
     }
 
     @GetMapping("/listpatient")
@@ -43,9 +38,4 @@ public class LegacyListController {
         return reportService.list(pageable, patientId, treatmentPathId, userId);
     }
 
-    @GetMapping("/treatmentlist")
-    public Page<TreatmentPathDto> listTreatmentPaths(Pageable pageable,
-                                                    @RequestParam Optional<Long> patientId) {
-        return treatmentPathService.list(pageable, patientId);
-    }
 }

--- a/src/main/java/Neuroflow/backend/treatmentpath/controller/TreatmentListController.java
+++ b/src/main/java/Neuroflow/backend/treatmentpath/controller/TreatmentListController.java
@@ -1,0 +1,37 @@
+package Neuroflow.backend.treatmentpath.controller;
+
+import Neuroflow.backend.treatmentpath.dto.TreatmentPathDto;
+import Neuroflow.backend.treatmentpath.service.TreatmentPathService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.Optional;
+
+/**
+ * Provides a legacy-compatible endpoint for listing treatment paths.
+ * <p>
+ * The frontend still requests <code>/api/v1/treatmentlist</code>; expose that
+ * path as an alias for the modern treatment-path list API so existing clients
+ * receive the expected data instead of a 404.
+ */
+@RestController
+@RequestMapping
+public class TreatmentListController {
+
+    private final TreatmentPathService treatmentPathService;
+
+    public TreatmentListController(TreatmentPathService treatmentPathService) {
+        this.treatmentPathService = treatmentPathService;
+    }
+
+    @GetMapping("/treatmentlist")
+    public Page<TreatmentPathDto> listTreatmentPaths(Pageable pageable,
+                                                     @RequestParam Optional<Long> patientId) {
+        return treatmentPathService.list(pageable, patientId);
+    }
+}
+


### PR DESCRIPTION
## Summary
- add a dedicated controller that exposes /treatmentlist as a legacy alias for treatment path listings
- streamline the legacy list controller now that treatment paths are handled by the new endpoint

## Testing
- mvn -DskipTests package

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69256fb72b4c8324988021c475231cd0)